### PR TITLE
Check if date separator of the supplied date value is different from …

### DIFF
--- a/validate-date.js
+++ b/validate-date.js
@@ -42,6 +42,12 @@ function dateValidator(dateValue, responses, dateFormat) {
         dateFormat = dateValue.includes("-") ? "yyyy-mm-dd" : "mm/dd/yyyy";
         }
 
+        // Check if date separator is different from the dateFormat
+        if(dateFormat.includes("-") && !dateValue.includes("-"))
+          return responses[0];
+        if(dateFormat.includes("/") && !dateValue.includes("/"))
+          return responses[0];
+
         if (dateFormat.length > 10 || dateFormat.length < 6) return responses[0];
 
         const formatSplit = dateValue.includes("-")


### PR DESCRIPTION
If the separator of the date is different from the dateFormat argument, the validateDate function will cause an error.

![image](https://user-images.githubusercontent.com/7559443/131453953-f2437c95-c37f-4c37-8a31-516975e2c7bb.png)

![image](https://user-images.githubusercontent.com/7559443/131453595-e0618d07-857c-4158-848d-36369e83e608.png)

So I added a code to the validate-date.js to check for this difference.


